### PR TITLE
Pin prettier version due to issue in prettier-plugin-jsdoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-config-prettier": "^10.1.1",
     "eslint-plugin-prettier": "^5.2.5",
     "eslint-plugin-unused-imports": "^4.1.4",
-    "prettier": "^3.5.3",
+    "prettier": "3.5.3",
     "prettier-plugin-jsdoc": "^1.3.2",
     "tsup": "^8.0.2",
     "typescript": "^5.3.3",


### PR DESCRIPTION
Due to a recent change in Prettier 3.6.0, the token parsing logic used in the prettier-plugin-jsdoc plugin stopped working. This caused our GH Actions workflow to update the SDK to fail. Until the issue is resolved, we are pinning the Prettier version to a known working one: 3.5.3.
