### PR TITLE
Allow longer comments to align with block comment style in OpenAPI spec

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,13 +1,13 @@
 {
   "env": {
     "node": true,
-    "es2021": true
+    "es2021": true,
   },
   "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended", "plugin:prettier/recommended"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": "latest",
-    "sourceType": "module"
+    "sourceType": "module",
   },
   "plugins": ["@typescript-eslint", "prettier", "unused-imports"],
   "rules": {
@@ -23,19 +23,19 @@
         "vars": "all",
         "varsIgnorePattern": "^_",
         "args": "after-used",
-        "argsIgnorePattern": "^_"
-      }
+        "argsIgnorePattern": "^_",
+      },
     ],
     "max-len": [
       "error",
       {
         "code": 120,
-        "comments": 120,
+        "comments": 125,
         "ignoreUrls": true,
         "ignoreStrings": true,
         "ignoreTemplateLiterals": true,
-        "ignoreRegExpLiterals": true
-      }
-    ]
-  }
+        "ignoreRegExpLiterals": true,
+      },
+    ],
+  },
 }


### PR DESCRIPTION
Allow longer comment lines to fix issue with code generation from OpenAPI spec. The document format requires more than 120 characters in certain cases.

Failed [Github Actions Workflow](https://github.com/adobe-commerce/aco-ts-sdk/actions/runs/18130996209/job/51597416843)